### PR TITLE
Implemented addJS to use cache.

### DIFF
--- a/src/TigerView.php
+++ b/src/TigerView.php
@@ -54,7 +54,17 @@ class TigerView extends View
 
     public function addJS($js)
     {
-        $this->_js[] = $js;
+        $filename = basename($js);
+        $data = file_get_contents(TigerApp::AppRoot() . "/" . $js);
+        $id = md5($filename);
+        $publicLocation = "cache/{$id}.js";
+        $publicLocationOnDisk = TigerApp::AppRoot() . "/public/" . $publicLocation;
+        if (!file_exists(dirname($publicLocationOnDisk))) {
+            mkdir(dirname($publicLocationOnDisk), 0777, true);
+        }
+        file_put_contents($publicLocationOnDisk, $data);
+        chmod($publicLocationOnDisk, 0664);
+        $this->_js[] = $publicLocation;
         return $this;
     }
 


### PR DESCRIPTION
Without this scripts currently aren't copied into the cache and are not served to the user.

It tries to serve then right out of the asset folder.